### PR TITLE
Add workspace configuration option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,18 @@ plugin 'cocoapods-bazel', {
 }
 ```
 
+## Plugin Configuration
+
+### `workspace`
+
+Path to the Bazel workspace directory, relative to the `Podfile`. Defaults to the directory the `Podfile` is within.
+
+```ruby
+plugin 'cocoapods-bazel', {
+  workspace: '../',
+}
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/cocoapods/bazel.rb
+++ b/lib/cocoapods/bazel.rb
@@ -17,7 +17,7 @@ module Pod
       end
 
       UI.titled_section 'Generating Bazel files' do
-        workspace = installer.config.installation_root
+        workspace = File.expand_path(config.workspace, installer.config.installation_root)
         sandbox = installer.sandbox
 
         # Ensure we declare the sandbox (Pods/) as a package so each Pod (as a package) belongs to sandbox root package instead

--- a/lib/cocoapods/bazel/config.rb
+++ b/lib/cocoapods/bazel/config.rb
@@ -53,6 +53,7 @@ module Pod
         buildifier: true,
         default_xcconfigs: {}.freeze,
         build_file_doc: '',
+        workspace: '',
         features: {
           experimental_deps_debug_and_release: false
         }
@@ -114,6 +115,10 @@ module Pod
 
       def build_file_doc
         to_h[:build_file_doc]
+      end
+
+      def workspace
+        to_h[:workspace]
       end
     end
   end


### PR DESCRIPTION
- Asana: https://app.asana.com/0/1203960884932166/1203960894292059/f

`workspace` allows you to specify the path to the Bazel workspace you're using, where previously it was assumed that the Podfile's directory was the same as your workspace, which may not be the case in monorepos.