### PR TITLE
[cocoapods-bazel] Make targets use external repository names

### DIFF
--- a/lib/cocoapods/bazel/target.rb
+++ b/lib/cocoapods/bazel/target.rb
@@ -51,9 +51,9 @@ module Pod
         if package == relative_to
           ":#{label}"
         elsif package_basename == label
-          "//#{package}"
+          "@#{package_basename}"
         else
-          "//#{package}:#{label}"
+          "@#{package_basename}//:#{label}"
         end
       end
 


### PR DESCRIPTION
Instead of using `//<pod dir>` for dependencies, use `@<pod
name>//:<label>`. This makes deps work properly in our repository.

Test Plan: Regenerated PINCache (deps on PINOperation) with `clyde ios
sync-pods` and `clyde ios build` passed.
